### PR TITLE
:hammer: Update Vite config for improved Docker compatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,16 @@
-import { defineConfig } from 'vite'
+import {defineConfig} from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+    plugins: [react()],
+    server: {
+        port: 5143,
+        host: true // Para permitir conexões externas (importante para Docker)
+    },
+    preview: {
+        port: 5143,
+        host: true
+    }
+
 })


### PR DESCRIPTION
- Set server and preview host to allow external connections (useful for Docker).
- Set custom port `5143` for both server and preview.