### PR TITLE
:hammer: Update sense-core-web port and healthcheck

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -81,7 +81,7 @@ services:
     image: diegoneves/sense-core-web:latest
     container_name: sense-core-web
     ports:
-      - "5143:5143"
+      - "5143:80"
     depends_on:
       sense-core-server:
         condition: service_healthy
@@ -90,7 +90,7 @@ services:
       - auth_services
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:5143" ]
+      test: [ "CMD", "curl", "-f", "http://localhost" ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
- Change exposed port from `5143` to `80`.
- Update healthcheck URL to align with new port.